### PR TITLE
Update CatalystCommons.sol

### DIFF
--- a/packages/contracts/contracts/CatalystCommons.sol
+++ b/packages/contracts/contracts/CatalystCommons.sol
@@ -12,6 +12,10 @@ contract CatalystCommons is ReentrancyGuard {
     uint256 public entryFee;
     uint256 public treasuryFeePercentage;
     uint256 public prizePoolPercentage;
+    uint256 public burnPercentage; // NEW: Burn percentage for losing rounds
+
+    // NEW: Event to log token burns
+    event TokensBurned(address indexed user, uint256 amount);
 
     struct Round {
         uint256 maxPlayerCount;
@@ -61,7 +65,8 @@ contract CatalystCommons is ReentrancyGuard {
         address _treasuryManager,
         uint256 _entryFee,
         uint256 _treasuryFeePercentage,
-        uint256 _prizePoolPercentage
+        uint256 _prizePoolPercentage,
+        uint256 _burnPercentage // NEW parameter
     ) {
         require(_treasuryFeePercentage + _prizePoolPercentage == 100, "Fee percentages must total 100");
         gameToken = IERC20(_gameToken);
@@ -70,6 +75,7 @@ contract CatalystCommons is ReentrancyGuard {
         entryFee = _entryFee;
         treasuryFeePercentage = _treasuryFeePercentage;
         prizePoolPercentage = _prizePoolPercentage;
+        burnPercentage = _burnPercentage; // Set burn percentage (e.g., 50 for 50%)
     }
 
     function updateFeeConfig(
@@ -186,12 +192,24 @@ contract CatalystCommons is ReentrancyGuard {
 
             emit RoundResolved(roundId, "THRESHOLD_MET", roundPlayers, distributions);
         } else {
+            // Failure branch: For losing rounds, 50% of each player's stake is burned and 50% goes to the treasury.
             for (uint256 i = 0; i < roundPlayers.length; i++) {
                 address player = roundPlayers[i];
                 uint256 playerStake = round.playerStakes[player];
                 distributions[i] = 0;
                 players[player].unavailableStakes -= playerStake;
-                treasuryBalance += playerStake;
+
+                // Calculate burn amount and treasury allocation.
+                // For a 50% burn, burnPercentage should be set to 50.
+                uint256 amountToBurn = (playerStake * burnPercentage) / 100;
+                uint256 amountToTreasury = playerStake - amountToBurn;  // 50% if burnPercentage is 50
+
+                // Burn tokens: If gameToken supports burn(), use that; otherwise, transfer to address(0)
+                require(gameToken.transfer(address(0), amountToBurn), "Burn transfer failed");
+                emit TokensBurned(player, amountToBurn);
+
+                // Add the remaining tokens to the treasury balance.
+                treasuryBalance += amountToTreasury;
             }
 
             emit RoundResolved(roundId, "THRESHOLD_NOT_MET", roundPlayers, distributions);


### PR DESCRIPTION
 Token Burning Mechanism for Losing Rounds

When a round fails (i.e., the total staked is less than the threshold), each player's stake is processed as follows:

50% (or the configured burn percentage) is burned: Tokens are transferred to address(0), effectively removing them from circulation. 50% is allocated to the treasury:
The remainder is added to the treasury balance.
Changes include:

Adding a new state variable burnPercentage (set in the constructor). Updating the constructor to accept the _burnPercentage parameter. Modifying the failure branch in resolveRound to:
Calculate the burn amount and treasury allocation. Burn tokens via transfer to address(0) and emit a TokensBurned event. Add the remaining amount to treasuryBalance.
This aligns with our design where only winning rounds multiply stakes, while losing rounds result in a 50/50 split (burn vs. treasury).