### PR TITLE
Rename Token to TestNostra for Clarity

### DIFF
--- a/packages/contracts/contracts/NostraToken.sol
+++ b/packages/contracts/contracts/NostraToken.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract NostraToken is ERC20, Ownable {
+contract TestNostraToken is ERC20, Ownable {
     uint256 public mintAmount;
     uint256 constant public TOTAL_SUPPLY = 1000000000;  // 1 billion tokens
     mapping(address => bool) public hasMinted;
 
     constructor(uint256 _initialMintAmount)
-        ERC20("NostraToken", "NST")
+        ERC20("TestNostraToken", "tNST")  // Updated name and symbol
         Ownable(msg.sender)
     {
         mintAmount = _initialMintAmount;


### PR DESCRIPTION
Updated the token name from "NostraToken" → "TestNostraToken" to differentiate it from the main token.

Changed the token symbol from "NST" → "tNST" to ensure clarity for testing.

No changes to the logic, only a name adjustment to avoid confusion.